### PR TITLE
Update nuspell version in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,12 @@ jobs:
     steps:
     - name: Install nuspell
       run: |
-        sudo add-apt-repository ppa:nuspell/ppa
-        sudo apt-get update
-        sudo apt-get install -y nuspell libnuspell-dev cmake hunspell-en-us
+        wget https://github.com/nuspell/nuspell/archive/refs/tags/v5.0.0.tar.gz -O - | tar -xz
+        cmake -S nuspell-* -B nuspell-build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=0
+        cmake --build nuspell-build -j 4
+        sudo cmake --install nuspell-build
+        sudo ldconfig
+        rm -rf nuspell-*
 
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
The PPA won't be updated anymore, and it should not be used because it will get retired. So now it's better to install nuspell from source.

Once newer Ubuntu (22.04) gets into Github Actions, there won't be need for PPA nor for building from source, just apt get `libnuspell-dev`.